### PR TITLE
[#96736448] Added the time format required by the Link API for dates

### DIFF
--- a/lib/live_paper.rb
+++ b/lib/live_paper.rb
@@ -7,6 +7,7 @@ require "live_paper/wm_trigger"
 require "live_paper/qr_trigger"
 require "live_paper/short_trigger"
 require "live_paper/version"
+require "live_paper/time_formats"
 require 'base64'
 require 'rest-client'
 require 'json'

--- a/lib/live_paper/time_formats.rb
+++ b/lib/live_paper/time_formats.rb
@@ -1,5 +1,3 @@
-#Move this file to a config folder
-
 Time::DATE_FORMATS[:live_paper_date_format] = lambda { |time|
   time.strftime("%Y-%m-%dT%H:%M:%S.%3N#{time.formatted_offset(false)}")
 }

--- a/lib/live_paper/time_formats.rb
+++ b/lib/live_paper/time_formats.rb
@@ -1,0 +1,5 @@
+#Move this file to a config folder
+
+Time::DATE_FORMATS[:live_paper_date_format] = lambda { |time|
+  time.strftime("%Y-%m-%dT%H:%M:%S.%3N#{time.formatted_offset(false)}")
+}

--- a/lib/live_paper/trigger.rb
+++ b/lib/live_paper/trigger.rb
@@ -33,18 +33,18 @@ module LivePaper
     end
 
     def default_start_date
-      Time.now.iso8601
+      Time.now.to_s(:live_paper_date_format)
     end
 
     def default_end_date
-      Time.now.advance(years: 1).iso8601
+      Time.now.advance(years: 1).to_s(:live_paper_date_format)
     end
 
     private
     def validate_attributes!
       raise ArgumentError, 'Required Attributes needed: name' unless all_present? [@name]
     end
- 
+
     def update_body
       {
         trigger: {


### PR DESCRIPTION
The startDate and endDate for triggers were not formatted as expected by the Link API.

I added a new datetime format because none of the existing formats worked out for us. 

The Ruby on Rails documentation suggests to add the new format in the file config/initializers/time_formats.rb

Since we don't have a config/initializers folder, I put it in the live_paper  folder.